### PR TITLE
Fixed Memory Handling in ListDeviceNames() in NFCContext.cs

### DIFF
--- a/NFCContext.cs
+++ b/NFCContext.cs
@@ -34,7 +34,7 @@ namespace SharpNFC
             var devices = new List<string>();
             for (int i = 0; i < devicesCount; i++)
             {
-                devices.Add(Marshal.PtrToStringAnsi(connectionStringsPointer + i * someUnknownCount));
+                devices.Add(Marshal.PtrToStringAnsi(connectionStringsPointer + i * Constants.NFC_BUFSIZE_CONNSTRING));
             }
 
             Marshal.FreeHGlobal(connectionStringsPointer);


### PR DESCRIPTION
The type `nfc_connstring` is defined as `typedef char nfc_connstring[NFC_BUFSIZE_CONNSTRING];` in nfc-types.h. Therefore, the pointer has to be moved by `NFC_BUFSIZE_CONNSTRING` (1024) bytes in order to get the next device name.
